### PR TITLE
Sync Repository Labels

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -1,0 +1,73 @@
+# Default GitHub labels
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: We are looking for community help
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
+  name: wontfix
+  description: The issue is expected and will not be fixed
+# Languages
+- color: 000000
+  name: github_actions
+  description: Pull requests that update GitHub Actions code
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code
+- color: 00ff44
+  name: shell
+  description: Pull requests that update Shell code
+- color: 0373fc
+  name: docker
+  description: Pull requests that update Docker code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
+# Components
+- color: f200f2
+  name: analyser
+  description: Pull requests that update analyser code
+- color: ff0073
+  name: git_hooks
+  description: Pull requests that update git hooks
+# Sizes
+- color: 00ff22
+  name: size/XS
+  description: Extra Small Pull Request
+- color: 03a319
+  name: size/S
+  description: Small Pull Request
+- color: f2bb05
+  name: size/M
+  description: Medium Pull Request
+- color: fc7e08
+  name: size/L
+  description: Large Pull Request
+- color: ad2e03
+  name: size/XL
+  description: Extra Large Pull Request
+- color: 751f01
+  name: size/XXL
+  description: Extra Extra Large Pull Request

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,29 @@
+name: "Sync labels"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/other-configurations/labels.yml
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configurations/labels.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to configure and synchronize GitHub labels. The most important changes include adding default labels, language-specific labels, component-specific labels, and size-specific labels in the `labels.yml` file, and setting up a GitHub Actions workflow to sync these labels.

Configuration of GitHub labels:

* [`.github/other-configurations/labels.yml`](diffhunk://#diff-c1b32711b0f3da3f5c7007cfaa4d9e94ae5430fea1f4e1256f6210bc6988553dR1-R73): Added default GitHub labels such as `bug`, `documentation`, and `enhancement`, along with language-specific labels like `github_actions` and `docker`, component-specific labels like `analyser` and `git_hooks`, and size-specific labels from `size/XS` to `size/XXL`.

Setup of GitHub Actions workflow:

* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6R1-R29): Created a workflow named "Sync labels" that triggers on pushes to the `main` branch and updates the labels based on the configuration in `labels.yml`. It uses the `micnncim/action-label-syncer` action to synchronize the labels.
Fixes #9 
