### PR TITLE
Add Markdown Link Checking

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,7 @@
+dirs:
+  - ./
+  - ./docs
+excludedFiles:
+  - ./CHANGELOG.md
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -32,6 +32,24 @@ jobs:
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
 
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Action workflow to check Markdown links in the repository. The changes include adding a new configuration file for the link checker and updating the workflow configuration to include the new link check job.

### New Configuration for Link Checker:

* [`.github/other-configurations/.linkspector.yml`](diffhunk://#diff-f9691f23ea6c4c34ecbaa23a98721e0aa3c7a94f2fcdd38f7b99fe863c5f6305R1-R7): Added configuration file specifying directories to check, excluded files, and status codes considered alive.

### Workflow Updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R35-R52): Added a new job `check-markdown-links` to the workflow, which uses the `UmbrellaDocs/action-linkspector` GitHub Action to check for broken links in Markdown files.

Fixes #8 
