### PR TITLE
Add List Repositories for User Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+#  Useful Commands
+
+- [Useful Commands](#useful-commands)
+  - [GitHub](#github)
+    - [Find all public repositories of a user](#find-all-public-repositories-of-a-user)
+
+
+## GitHub
+
+### Find all public repositories of a user
+
+This command will list all the public repositories of a user that are not archived and not forked.
+
+```bash
+gh repo list --no-archived --source --visibility public --json name --jq '.[].name'
+```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-#  Useful Commands
+# Useful Commands
 
 - [Useful Commands](#useful-commands)
   - [GitHub](#github)
     - [Find all public repositories of a user](#find-all-public-repositories-of-a-user)
-
 
 ## GitHub
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `README.md` file. The change adds a new section titled "Useful Commands" with a subsection for GitHub commands, including an example command to find all public repositories of a user.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R16): Added a "Useful Commands" section with a GitHub command to list all public repositories of a user that are not archived and not forked.