### PR TITLE
Add Command to Get Owner and Repository Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,11 @@ git commit -m "Squashed all commits"
 This command will list all the public repositories of a user that are not archived and not forked.
 
 ```bash
+# Just the names of the repositories
 gh repo list --no-archived --source --visibility public --json name --jq '.[].name'
+```
+
+```bash
+# Names of the repositories with the owner
+gh repo list --no-archived --source --visibility public --json nameWithOwner --jq '.[].nameWithOwner'
 ```


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `README.md` file to provide additional examples for listing GitHub repositories using the `gh` CLI tool.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R34): Added a new example command to list the names of public repositories along with their owners.
