### PR TITLE
Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -52,6 +52,20 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest
@@ -64,7 +78,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.2.2
+        uses: astral-sh/setup-uv@v5.3.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -72,7 +86,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.8
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -89,10 +103,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.8
+        uses: github/codeql-action/init@v3.28.10
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.8
+        uses: github/codeql-action/analyze@v3.28.10


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows in the `.github/workflows/code-checks.yml` file. The changes focus on adding a new job for checking the Justfile format and updating the versions of several actions used in the workflow.

Updates to GitHub Actions workflows:

* Added a new job `check-justfile-format` to validate the format of the Justfile.
* Updated the version of `astral-sh/setup-uv` action from `v5.2.2` to `v5.3.0`.
* Updated the version of `github/codeql-action/upload-sarif` action from `v3.28.8` to `v3.28.10`.
* Updated the version of `github/codeql-action/init` action from `v3.28.8` to `v3.28.10`.
* Updated the version of `github/codeql-action/analyze` action from `v3.28.8` to `v3.28.10`.

Fixes #50
