### PR TITLE
Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-    commit-message:
-      prefix: "deps(github-actions)"
     schedule:
       interval: "daily"
       time: "01:00"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/dependabot.yml` file to simplify the configuration by removing the commit message prefix for GitHub Actions dependency updates.

Configuration simplification:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-L8): Removed the `commit-message` section that specified a prefix for GitHub Actions dependency updates.