### PR TITLE
Add Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -111,3 +111,17 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13
+
+  pinact-verify:
+    name: Pinact Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"

--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Checks:
+      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces support for integrating and validating `pinact` within the project's workflows and development process. The most important changes include adding a new `pinact-verify` job to the GitHub Actions workflow, defining `pinact` commands in the `Justfile`, and incorporating `pinact` checks into the pre-commit hooks.

### GitHub Actions Workflow Updates:
* Added a new `pinact-verify` job to `.github/workflows/code-checks.yml`. This job includes steps for checking out the repository, installing the latest version of `uv`, and preparing for `pinact` verification.

### Development Workflow Enhancements:
* Added `pinact` commands in the `Justfile` to support running, verifying, and updating `pinact` configurations. These commands use a specific configuration file located at `.github/other-configurations/pinact.yml`.

### Pre-commit Hook Integration:
* Updated `lefthook.yml` to include a new `Pinact Checks` pre-commit hook that runs the `pinact-check` command defined in the `Justfile`.