### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.4
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Check Justfile Format
         run: just format-check
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new configuration file for Pinact, updates pinned versions of GitHub Actions in the `code-checks.yml` workflow, and ensures compliance with specific schema standards. These changes improve configuration management and enhance the stability and reproducibility of workflows.

### New configuration file:

* [`.github/other-configurations/pinact.yml`](diffhunk://#diff-c2e684c61036562879b1062fb69ab67d446e19354f7a45ef92b14f611a051bc5R1-R9): Added a new configuration file for Pinact, including schema validation and rules to ignore specific actions (`actions/.*` and `github/codeql-action/.*`).

### Workflow updates:

* `.github/workflows/code-checks.yml`: Updated the pinned versions of the following GitHub Actions to specific commit SHAs for improved stability:
  - `super-linter/super-linter/slim` updated to `4e8a7c2bf106c4c766c816b35ec612638dc9b6b2`.
  - `UmbrellaDocs/action-linkspector` updated to `a0567ce1c7c13de4a2358587492ed43cab5d0102`.
  - `extractions/setup-just` updated to `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff`.