### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -80,15 +80,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.1
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.13
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow configuration and `Justfile` to improve dependency management and streamline the execution of code checks. The most important changes include upgrading the `setup-uv` action, introducing the `setup-just` action, and modifying the commands for running and formatting `zizmor` checks.

### Workflow updates:

* Upgraded the `setup-uv` action to a specific commit corresponding to version `v6.0.1` for improved stability and compatibility.
* Added the `setup-just` action to set up `Just`, enabling the use of `Justfile` for task automation.
* Updated the `zizmor` execution command in the workflow to use the `just zizmor-check-sarif` task, simplifying the workflow and aligning it with the `Justfile`.
* Upgraded the `upload-sarif` action to version `v3.28.17` for compatibility and bug fixes.

### `Justfile` updates:

* Added a new `zizmor-check-sarif` task to the `Justfile`, which runs `zizmor` with SARIF output formatting for better integration with the workflow.
* Updated the `zizmor-check` task to use `uvx` for running `zizmor`, ensuring consistency with the updated workflow setup.