### PR TITLE
Update SuperLinter to 7.4.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -87,7 +87,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -104,9 +104,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        uses: github/codeql-action/init@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           languages: actions
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+        uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -47,6 +47,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Dependency Review
-        uses: actions/dependency-review-action@38ecb5b593bf0eb19e335c03f97670f792489a8b # v4.7.0
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows to use newer versions of their respective actions. The updates ensure the workflows benefit from the latest features, bug fixes, and security improvements.

### Updates to `.github/workflows/code-checks.yml`:

* Updated `super-linter` action from version `v7.3.0` to `v7.4.0` for linting the codebase.
* Updated `upload-sarif` action from version `v3.28.17` to `v3.28.18` for uploading SARIF files.
* Updated `CodeQL` actions (`init` and `analyze`) from version `v3.28.17` to `v3.28.18` for code scanning and analysis.

### Updates to `.github/workflows/pull-request-tasks.yml`:

* Updated `dependency-review-action` from version `v4.7.0` to `v4.7.1` for reviewing dependencies.