### PR TITLE
Remove SuperLinter

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,28 +16,6 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  check-code-quality:
-    name: Check Code Quality
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Lint Code Base
-        uses: super-linter/super-linter@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LINTER_RULES_PATH: .github/super-linter-configurations
-          YAML_ERROR_ON_WARNING: true
-          VALIDATE_EDITORCONFIG: false
-          VALIDATE_GIT_COMMITLINT: false
-
   common-code-checks:
     name: Common Code Checks
     permissions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the dedicated "Check Code Quality" job from the `.github/workflows/code-checks.yml` workflow file. The job previously ran code linting and quality checks using Super Linter and is no longer part of the workflow.

Workflow update:

* Removed the `check-code-quality` job, which included repository checkout and code linting steps using Super Linter, as well as related environment variables and permissions from `.github/workflows/code-checks.yml`.
