### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -16,6 +16,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@12d9019b6d1fa2e3dc442e372d66aed30cafdb59 # v2026.01.17.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@12d9019b6d1fa2e3dc442e372d66aed30cafdb59 # v2026.01.17.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
     with:
       language: ${{ matrix.language }}
 
@@ -38,6 +38,6 @@ jobs:
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@12d9019b6d1fa2e3dc442e372d66aed30cafdb59 # v2026.01.17.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -15,6 +15,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@12d9019b6d1fa2e3dc442e372d66aed30cafdb59 # v2026.01.17.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # For writing labels to the repository
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@12d9019b6d1fa2e3dc442e372d66aed30cafdb59 # v2026.01.17.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflow files to use newer versions of shared reusable workflows. The main change is updating the referenced commit SHA and version tag for each workflow, ensuring that the latest improvements and fixes from the shared workflows repository are used.

**Workflow reference updates:**

* Updated the reusable workflow reference in `.github/workflows/code-checks.yml` for both `codeql-analysis.yml` and `common-code-checks.yml` to use commit `598eb95b8974f9b0ea4de1bea53d815bc5c02a9e` (v2026.01.28.01) instead of the previous version. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L30-R30) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L41-R41)
* Updated the reusable workflow reference in `.github/workflows/pull-request-tasks.yml` to the same new version and commit.
* Updated the reusable workflow reference in `.github/workflows/sync-labels.yml` to the new version and commit.
* Updated the reusable workflow reference in `.github/workflows/clean-caches.yml` to the new version and commit.
