### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -16,6 +16,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
     with:
       language: ${{ matrix.language }}
 
@@ -38,6 +38,6 @@ jobs:
       actions: read # Allow the workflow to read actions metadata
       pull-requests: write # Allow the workflow to create and modify pull request comments
       security-events: write # Allow the workflow to upload analysis results
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -15,6 +15,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write # For writing labels and comments on PRs
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,6 +20,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # For writing labels to the repository
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@598eb95b8974f9b0ea4de1bea53d815bc5c02a9e # v2026.01.28.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@df2f9791faacdfc1e3a041fbbc83e13bfbba1259 # v2026.02.21.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         description: Scan for secrets using Gitleaks
         language_version: "go1.25"
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.10
+    rev: v1.7.11
     hooks:
       - id: actionlint
         name: Actionlint
@@ -39,7 +39,7 @@ repos:
         name: EditorConfig Checker
         description: Validates files against .editorconfig rules
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.20.0
+    rev: v1.22.0
     hooks:
       - id: zizmor
         name: Zizmor
@@ -52,7 +52,7 @@ repos:
         language: node
         entry: prettier
         additional_dependencies:
-          - prettier@3.7.4
+          - prettier@3.8.1
         args: ["--check"]
         files: "(?i)(\\.(md|markdown|ya?ml|json)$|^(README|LICENSE|CONTRIBUTING|CODE_OF_CONDUCT|SECURITY|SUPPORT)(\\.md)?$)"
       - id: justfile-format-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request primarily updates the versions of reusable GitHub Actions workflows and pre-commit hooks to their latest releases. These updates ensure that the project benefits from the latest features, bug fixes, and security improvements provided by upstream maintainers.

**Workflow Version Updates:**

* Updated all references to reusable workflows in `.github/workflows` files (`common-clean-caches.yml`, `codeql-analysis.yml`, `common-code-checks.yml`, `common-pull-request-tasks.yml`, and `common-sync-labels.yml`) to use the latest commit and version tag (`v2026.02.21.01`) from `JackPlowman/reusable-workflows`. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL19-R19) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L30-R30) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L41-R41) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL18-R18) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L23-R23)

**Pre-commit Hook Updates:**

* Upgraded the `actionlint` hook to version `v1.7.11` in `.pre-commit-config.yaml`.
* Upgraded the `zizmor` hook to version `v1.22.0` in `.pre-commit-config.yaml`.
* Updated the `prettier` dependency to version `3.8.1` in the `prettier-format-check` hook.