### PR TITLE
Add Enable Workflow Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     - [Squash all commits of a branch into one](#squash-all-commits-of-a-branch-into-one)
   - [GitHub](#github)
     - [Find all public repositories of a user](#find-all-public-repositories-of-a-user)
+    - [Enable all workflows of all public repositories of a user](#enable-all-workflows-of-all-public-repositories-of-a-user)
   - [Scoop](#scoop)
     - [Update Scoop Packages](#update-scoop-packages)
 
@@ -38,6 +39,32 @@ gh repo list --no-archived --source --visibility public -L 300 --json name --jq 
 ```bash
 # Names of the repositories with the owner (max 300)
 gh repo list --no-archived --source --visibility public -L 300 --json nameWithOwner --jq '.[].nameWithOwner' | sort
+```
+
+### Enable all workflows of all public repositories of a user
+
+```bash
+USER=your-github-username
+
+export GH_PAGER=cat
+export PAGER=cat
+
+gh repo list "$USER" \
+  --limit 1000 \
+  --visibility public \
+  --no-archived \
+  --json nameWithOwner,isFork \
+  --jq '.[] | select(.isFork == false) | .nameWithOwner' |
+while read repo; do
+  echo "Checking $repo"
+
+  gh api --paginate "repos/$repo/actions/workflows" \
+    --jq '.workflows[] | select(.state != "active") | .id' |
+  while read id; do
+    echo "  Enabling workflow $id"
+    GH_PAGER=cat gh api -X PUT "repos/$repo/actions/workflows/$id/enable"
+  done
+done
 ```
 
 ## Scoop


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `README.md` to add documentation for enabling all GitHub Actions workflows across all public repositories of a user. The main change is the addition of a new section with a Bash script to automate this process.

**Documentation Updates:**

* Added a new entry to the table of contents for "Enable all workflows of all public repositories of a user".
* Added a new section with a Bash script that iterates through all non-fork public repositories of a specified user and enables any disabled GitHub Actions workflows.